### PR TITLE
Update to e-g 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,5 @@ circle-ci = { repository = "embedded-graphics/tinybmp", branch = "master" }
 name = "embedded_graphics"
 
 [dependencies]
-embedded-graphics = "0.7.0-beta.2"
+embedded-graphics = "0.7.0"
 nom = { version = "6.0.1", default-features = false }


### PR DESCRIPTION
This PR updates the e-g dependency to 0.7.0.