### PR TITLE
Fix doc links

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,19 +1,19 @@
 # Check that everything (tests, benches, etc) builds in std environments
 precheck_steps: &precheck_steps
-  docker:
-    - image: jamwaffles/circleci-embedded-graphics:1.40.0-cimg
+  docker: &docker
+    - image: jamwaffles/circleci-embedded-graphics:1.40.0-3
       auth:
         username: jamwaffles
         password: $DOCKERHUB_PASSWORD
   steps:
     - checkout
-    - restore_cache:
+    - restore_cache: &restore_cache
         key: v1-{{ .Environment.CIRCLE_PROJECT_REPONAME }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "Cargo.toml" }}
     - run: rustup default ${RUST_VERSION:-stable}
     - run: rustup component add rustfmt
     - run: cargo update
     - run: just build
-    - save_cache:
+    - save_cache: &save_cache
         key: v1-{{ .Environment.CIRCLE_PROJECT_REPONAME }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "Cargo.toml" }}
         paths:
           - ./target
@@ -21,24 +21,14 @@ precheck_steps: &precheck_steps
 
 # Build crates for embedded target
 target_steps: &target_steps
-  docker:
-    - image: jamwaffles/circleci-embedded-graphics:1.40.0-cimg
-      auth:
-        username: jamwaffles
-        password: $DOCKERHUB_PASSWORD
+  docker: *docker
   steps:
     - checkout
-    - restore_cache:
-        keys:
-          - v1-{{ .Environment.CIRCLE_PROJECT_REPONAME }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "Cargo.toml" }}
+    - restore_cache: *restore_cache
     - run: just install-targets
     - run: cargo update
     - run: just build-targets --release
-    - save_cache:
-        key: v1-{{ .Environment.CIRCLE_PROJECT_REPONAME }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "Cargo.toml" }}
-        paths:
-          - ./target
-          - /home/circleci/.cargo/registry
+    - save_cache: *save_cache
 
 version: 2
 jobs:

--- a/src/dynamic_bmp.rs
+++ b/src/dynamic_bmp.rs
@@ -20,6 +20,8 @@ use crate::{
 /// `DynamicBmp` works for all embedded-graphics draw targets that use a color type that implements
 /// `From` for `Rgb555, `Rgb565`, `Rgb888` and `Gray8`, like every `Rgb...` and `Bgr...` type
 /// included in embedded-graphics.
+///
+/// [`Bmp`]: struct.Bmp.html
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct DynamicBmp<'a, C> {
     raw_bmp: RawBmp<'a>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,15 +167,6 @@ where
     }
 
     /// Returns an iterator over the pixels in this image.
-    ///
-    /// The iterator automatically converts the pixel colors into an `embedded-graphics` color type,
-    /// that is when the [`from_slice`] constructor was called. This method isn't available when
-    /// the [`from_slice_raw`] constructor was used and the pixel can only be accessed by using the
-    /// [`raw_pixels`] method.
-    ///
-    /// [`from_slice`]: #method.from_slice
-    /// [`from_slice_raw`]: #method.from_slice_raw
-    /// [`raw_pixels`]: #method.raw_pixels
     pub fn pixels<'b>(&'b self) -> Pixels<'b, 'a, C> {
         Pixels::new(self.raw_bmp.pixels())
     }


### PR DESCRIPTION
This repo still used an older version of the docker image which contained an outdated version of `cargo-deadlinks`. Because of this some broken links in the docs weren't detected by `just build`.