### PR TITLE
Version 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## [Unreleased] - ReleaseDate
 
+## [0.3.1] - 2021-06-16
+
 ### Changed
 
 - [#13](https://github.com/embedded-graphics/tinybmp/pull/13) Bump embedded-graphics minimum version from 0.7.0 to 0.7.1
@@ -117,8 +119,9 @@
 - Release `tinybmp` crate to crates.io
 
 <!-- next-url -->
+[unreleased]: https://github.com/embedded-graphics/tinybmp/compare/v0.3.1...HEAD
 
-[unreleased]: https://github.com/embedded-graphics/tinybmp/compare/v0.3.0...HEAD
+[0.3.1]: https://github.com/embedded-graphics/tinybmp/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/embedded-graphics/tinybmp/compare/v0.3.0-beta.2...v0.3.0
 [0.3.0-beta.2]: https://github.com/embedded-graphics/tinybmp/compare/v0.3.0-beta.1...v0.3.0-beta.2
 [0.3.0-beta.1]: https://github.com/embedded-graphics/tinybmp/compare/v0.3.0-alpha.1...v0.3.0-beta.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tinybmp"
 description = "No-std, low memory footprint BMP image loader"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["James Waples <james@wapl.es>", "Ralf Fuest <mail@rfuest.de>"]
 edition = "2018"
 repository = "https://github.com/embedded-graphics/tinybmp"


### PR DESCRIPTION
`cargo-release` committed the changes to my fork instead of this main `embedded-graphics/tinybmp` repo.