### PR TITLE
Remove nom dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ harness = false
 
 [dependencies]
 embedded-graphics = "0.7.1"
-nom = { version = "6.0.1", default-features = false }
 
 [dev-dependencies]
 clap = { version = "3.1.6", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,15 @@ circle-ci = { repository = "embedded-graphics/tinybmp", branch = "master" }
 [[test]]
 name = "embedded_graphics"
 
+[[bench]]
+name = "parse"
+harness = false
+
 [dependencies]
 embedded-graphics = "0.7.1"
 nom = { version = "6.0.1", default-features = false }
 
 [dev-dependencies]
 clap = { version = "3.1.6", features = ["derive"] }
+criterion = "0.3.5"
 embedded-graphics-simulator = "0.3.0"

--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -1,0 +1,14 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use embedded_graphics::pixelcolor::Rgb888;
+use tinybmp::Bmp;
+
+const BMP_FILE: &[u8] = include_bytes!("../tests/colors_rgb888_24bit.bmp");
+
+fn parser_benchmarks(c: &mut Criterion) {
+    c.bench_function("parse BMP", |b| {
+        b.iter(|| Bmp::<Rgb888>::from_slice(BMP_FILE).unwrap())
+    });
+}
+
+criterion_group!(benches, parser_benchmarks);
+criterion_main!(benches);

--- a/src/color_table.rs
+++ b/src/color_table.rs
@@ -1,5 +1,6 @@
 use core::convert::TryInto;
-use embedded_graphics::prelude::{PixelColor, RawData};
+
+use embedded_graphics::prelude::*;
 
 /// Color table.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/dynamic_bmp.rs
+++ b/src/dynamic_bmp.rs
@@ -1,4 +1,5 @@
 use core::marker::PhantomData;
+
 use embedded_graphics::{
     pixelcolor::{Gray8, PixelColor, Rgb555, Rgb565, Rgb888},
     prelude::*,

--- a/src/header/dib_header.rs
+++ b/src/header/dib_header.rs
@@ -1,6 +1,6 @@
 //! Device Independent Bitmap (DIB) header.
 
-use embedded_graphics::geometry::Size;
+use embedded_graphics::prelude::*;
 
 use crate::{
     header::CompressionMethod,

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -5,14 +5,15 @@
 
 use embedded_graphics::prelude::*;
 
-mod dib_header;
-
 use crate::{
     color_table::ColorTable,
-    header::dib_header::DibHeader,
     parser::{le_u16, le_u32, take, take_slice},
     ParseError,
 };
+
+mod dib_header;
+
+use dib_header::DibHeader;
 
 /// Bits per pixel.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,6 +113,7 @@
 mod color_table;
 mod dynamic_bmp;
 mod header;
+mod parser;
 mod pixels;
 mod raw_bmp;
 mod raw_pixels;
@@ -230,4 +231,23 @@ pub enum ParseError {
 
     /// The image format isn't supported by `DynamicBmp`.
     UnsupportedDynamicBmpFormat,
+
+    /// Unexpected end of file.
+    UnexpectedEndOfFile,
+
+    /// Invalid file signatures.
+    ///
+    /// BMP files must start with `BM`.
+    InvalidFileSignature,
+
+    /// Missing color table.
+    ///
+    /// Images with <= 8 BPP must contain a color table.
+    MissingColorTable,
+
+    /// Unsupported compression method.
+    UnsupportedCompressionMethod(u32),
+
+    /// Unsupported header length.
+    UnsupportedHeaderLength(u32),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,10 @@
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 
+use core::marker::PhantomData;
+
+use embedded_graphics::{prelude::*, primitives::Rectangle};
+
 mod color_table;
 mod dynamic_bmp;
 mod header;
@@ -117,9 +121,6 @@ mod parser;
 mod pixels;
 mod raw_bmp;
 mod raw_pixels;
-
-use core::marker::PhantomData;
-use embedded_graphics::{prelude::*, primitives::Rectangle};
 
 pub use crate::{
     dynamic_bmp::DynamicBmp,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,0 +1,31 @@
+use crate::ParseError;
+
+pub fn take<const N: usize>(input: &[u8]) -> Result<(&[u8], [u8; N]), ParseError> {
+    if let (Some(value), Some(rest)) = (input.get(0..N), input.get(N..)) {
+        Ok((rest, value.try_into().unwrap()))
+    } else {
+        Err(ParseError::UnexpectedEndOfFile)
+    }
+}
+
+pub fn take_slice(input: &[u8], length: usize) -> Result<(&[u8], &[u8]), ParseError> {
+    if let (Some(value), Some(rest)) = (input.get(0..length), input.get(length..)) {
+        Ok((rest, value.try_into().unwrap()))
+    } else {
+        Err(ParseError::UnexpectedEndOfFile)
+    }
+}
+
+pub fn le_u16(input: &[u8]) -> Result<(&[u8], u16), ParseError> {
+    let (input, value) = take::<2>(input)?;
+    Ok((input, u16::from_le_bytes(value)))
+}
+
+pub fn le_u32(input: &[u8]) -> Result<(&[u8], u32), ParseError> {
+    let (input, value) = take::<4>(input)?;
+    Ok((input, u32::from_le_bytes(value)))
+}
+
+pub fn le_i32(input: &[u8]) -> Result<(&[u8], i32), ParseError> {
+    le_u32(input).map(|(input, value)| (input, value as i32))
+}

--- a/src/pixels.rs
+++ b/src/pixels.rs
@@ -1,4 +1,5 @@
 use core::marker::PhantomData;
+
 use embedded_graphics::prelude::*;
 
 use crate::{raw_pixels::RawPixels, RawPixel};

--- a/src/raw_bmp.rs
+++ b/src/raw_bmp.rs
@@ -34,10 +34,11 @@ impl<'a> RawBmp<'a> {
     /// [`from_slice`]: #method.from_slice
     /// [`pixels`]: #method.pixels
     pub fn from_slice(bytes: &'a [u8]) -> Result<Self, ParseError> {
-        let (_remaining, (header, color_table)) =
-            Header::parse(bytes).map_err(|_| ParseError::Header)?;
+        let (_remaining, (header, color_table)) = Header::parse(bytes)?;
 
-        let image_data = &bytes[header.image_data_start..];
+        let image_data = &bytes
+            .get(header.image_data_start..)
+            .ok_or(ParseError::UnexpectedEndOfFile)?;
 
         Ok(Self {
             header,


### PR DESCRIPTION
While I like `nom` I find it hard to implement error handling with `nom`. After fighting with `nom`s error types for a while I noticed that we actually use a very limited set of `nom` functions in this crate. So I decided to try to reimplement the necessary function and it turned out to only needed about 30 lines of code to implement all necessary functions.

The code is missing tests for the new errors and the parser functions, but it should be enough to decide if we want to stick with `nom` or use this approach.