### PR TITLE
Add pixel getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#28](https://github.com/embedded-graphics/tinybmp/pull/28) Added a `ColorTable` struct and the `RawBmp::color_table` getter to access the BMP files color table.
 - [#28](https://github.com/embedded-graphics/tinybmp/pull/28) Added support for 4bpp images with color table.
 - [#28](https://github.com/embedded-graphics/tinybmp/pull/28) Added `display` example to display BMP images using the embedded-graphics simulator.
+- [#34](https://github.com/embedded-graphics/tinybmp/pull/34) Added `Bmp::pixel` and `RawBmp::pixel` to access individual pixels.
 
 ### Changed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,6 +195,45 @@ where
         Pixels::new(self)
     }
 
+    /// Returns the color of a pixel.
+    ///
+    /// Returns `None` if `p` is outside the image bounding box.
+    pub fn pixel(&self, p: Point) -> Option<C> {
+        match self.raw_bmp.color_type {
+            ColorType::Index1 => self
+                .raw_bmp
+                .color_table()
+                .and_then(|color_table| color_table.get(self.raw_bmp.pixel(p)?))
+                .map(Into::into),
+            ColorType::Index4 => self
+                .raw_bmp
+                .color_table()
+                .and_then(|color_table| color_table.get(self.raw_bmp.pixel(p)?))
+                .map(Into::into),
+            ColorType::Index8 => self
+                .raw_bmp
+                .color_table()
+                .and_then(|color_table| color_table.get(self.raw_bmp.pixel(p)?))
+                .map(Into::into),
+            ColorType::Rgb555 => self
+                .raw_bmp
+                .pixel(p)
+                .map(|raw| Rgb555::from(RawU16::from_u32(raw)).into()),
+            ColorType::Rgb565 => self
+                .raw_bmp
+                .pixel(p)
+                .map(|raw| Rgb565::from(RawU16::from_u32(raw)).into()),
+            ColorType::Rgb888 => self
+                .raw_bmp
+                .pixel(p)
+                .map(|raw| Rgb888::from(RawU24::from_u32(raw)).into()),
+            ColorType::Xrgb8888 => self
+                .raw_bmp
+                .pixel(p)
+                .map(|raw| Rgb888::from(RawU24::from_u32(raw)).into()),
+        }
+    }
+
     /// Returns a reference to the raw BMP image.
     ///
     /// The [`RawBmp`] instance can be used to access lower level information about the BMP file.

--- a/src/raw_bmp.rs
+++ b/src/raw_bmp.rs
@@ -94,6 +94,9 @@ impl<'a> RawBmp<'a> {
             return None;
         }
 
+        // The specialized implementations of `Iterator::nth` for `Chunks` and
+        // `RawDataSlice::IntoIter` are `O(1)`, which also makes this method `O(1)`.
+
         let mut row_chunks = self.image_data.chunks_exact(self.header.bytes_per_row());
         let row = match self.header.row_order {
             RowOrder::BottomUp => row_chunks.nth_back(p.y as usize),

--- a/src/raw_iter.rs
+++ b/src/raw_iter.rs
@@ -71,6 +71,19 @@ enum DynamicRawColors<'a> {
     Bpp32(RawColors<'a, RawU32>),
 }
 
+impl<'a> DynamicRawColors<'a> {
+    pub fn new(raw_bmp: &'a RawBmp<'a>) -> Self {
+        match raw_bmp.header().bpp {
+            Bpp::Bits1 => DynamicRawColors::Bpp1(RawColors::new(raw_bmp)),
+            Bpp::Bits4 => DynamicRawColors::Bpp4(RawColors::new(raw_bmp)),
+            Bpp::Bits8 => DynamicRawColors::Bpp8(RawColors::new(raw_bmp)),
+            Bpp::Bits16 => DynamicRawColors::Bpp16(RawColors::new(raw_bmp)),
+            Bpp::Bits24 => DynamicRawColors::Bpp24(RawColors::new(raw_bmp)),
+            Bpp::Bits32 => DynamicRawColors::Bpp32(RawColors::new(raw_bmp)),
+        }
+    }
+}
+
 /// Iterator over individual BMP pixels.
 ///
 /// Each pixel is returned as a `u32` regardless of the bit depth of the source image.
@@ -82,19 +95,10 @@ pub struct RawPixels<'a> {
 
 impl<'a> RawPixels<'a> {
     pub(crate) fn new(raw_bmp: &'a RawBmp<'a>) -> Self {
-        let header = raw_bmp.header();
-
-        let colors = match header.bpp {
-            Bpp::Bits1 => DynamicRawColors::Bpp1(RawColors::new(raw_bmp)),
-            Bpp::Bits4 => DynamicRawColors::Bpp4(RawColors::new(raw_bmp)),
-            Bpp::Bits8 => DynamicRawColors::Bpp8(RawColors::new(raw_bmp)),
-            Bpp::Bits16 => DynamicRawColors::Bpp16(RawColors::new(raw_bmp)),
-            Bpp::Bits24 => DynamicRawColors::Bpp24(RawColors::new(raw_bmp)),
-            Bpp::Bits32 => DynamicRawColors::Bpp32(RawColors::new(raw_bmp)),
-        };
-        let points = Rectangle::new(Point::zero(), header.image_size).points();
-
-        Self { colors, points }
+        Self {
+            colors: DynamicRawColors::new(raw_bmp),
+            points: Rectangle::new(Point::zero(), raw_bmp.header().image_size).points(),
+        }
     }
 }
 

--- a/tests/logo.rs
+++ b/tests/logo.rs
@@ -101,10 +101,40 @@ where
     Framebuffer::from_image(bmp)
 }
 
+fn draw_bmp_pixel_getter<C>(data: &[u8]) -> Framebuffer<C>
+where
+    C: PixelColor + From<Rgb555> + From<Rgb565> + From<Rgb888> + std::fmt::Debug,
+{
+    let bmp = Bmp::<C>::from_slice(data).unwrap();
+
+    let mut fb = Framebuffer::new();
+
+    let bb = bmp.bounding_box();
+    assert_eq!(bb.top_left, Point::zero());
+    assert_eq!(bb.size, Size::new(240, 320));
+    assert_eq!(bb.points().count(), 320 * 240);
+
+    bmp.bounding_box()
+        .points()
+        .map(|p| Pixel(p, bmp.pixel(p).unwrap()))
+        .draw(&mut fb)
+        .unwrap();
+
+    fb
+}
+
 #[test]
 fn logo_indexed_1bpp() {
     let raw = draw_raw::<Bgr888>(include_bytes!("logo-indexed-1bpp.raw"));
     let bmp = draw_bmp::<Bgr888>(include_bytes!("logo-indexed-1bpp.bmp"));
+
+    bmp.assert_eq(&raw);
+}
+
+#[test]
+fn logo_indexed_1bpp_pixel_getter() {
+    let raw = draw_raw::<Bgr888>(include_bytes!("logo-indexed-1bpp.raw"));
+    let bmp = draw_bmp_pixel_getter::<Bgr888>(include_bytes!("logo-indexed-1bpp.bmp"));
 
     bmp.assert_eq(&raw);
 }
@@ -118,9 +148,25 @@ fn logo_indexed_4bpp() {
 }
 
 #[test]
+fn logo_indexed_4bpp_pixel_getter() {
+    let raw = draw_raw::<Bgr888>(include_bytes!("logo-indexed-4bpp.raw"));
+    let bmp = draw_bmp_pixel_getter::<Bgr888>(include_bytes!("logo-indexed-4bpp.bmp"));
+
+    bmp.assert_eq(&raw);
+}
+
+#[test]
 fn logo_indexed_8bpp() {
     let raw = draw_raw::<Bgr888>(include_bytes!("logo-indexed-8bpp.raw"));
     let bmp = draw_bmp::<Bgr888>(include_bytes!("logo-indexed-8bpp.bmp"));
+
+    bmp.assert_eq(&raw);
+}
+
+#[test]
+fn logo_indexed_8bpp_pixel_getter() {
+    let raw = draw_raw::<Bgr888>(include_bytes!("logo-indexed-8bpp.raw"));
+    let bmp = draw_bmp_pixel_getter::<Bgr888>(include_bytes!("logo-indexed-8bpp.bmp"));
 
     bmp.assert_eq(&raw);
 }
@@ -134,9 +180,25 @@ fn logo_rgb555() {
 }
 
 #[test]
+fn logo_rgb555_pixel_getter() {
+    let raw = draw_raw::<Rgb555>(include_bytes!("logo-rgb555.raw"));
+    let bmp = draw_bmp_pixel_getter::<Rgb555>(include_bytes!("logo-rgb555.bmp"));
+
+    bmp.assert_eq(&raw);
+}
+
+#[test]
 fn logo_rgb565() {
     let raw = draw_raw::<Rgb565>(include_bytes!("logo-rgb565.raw"));
     let bmp = draw_bmp::<Rgb565>(include_bytes!("logo-rgb565.bmp"));
+
+    bmp.assert_eq(&raw);
+}
+
+#[test]
+fn logo_rgb565_pixel_getter() {
+    let raw = draw_raw::<Rgb565>(include_bytes!("logo-rgb565.raw"));
+    let bmp = draw_bmp_pixel_getter::<Rgb565>(include_bytes!("logo-rgb565.bmp"));
 
     bmp.assert_eq(&raw);
 }
@@ -150,9 +212,25 @@ fn logo_rgb888_24bpp() {
 }
 
 #[test]
+fn logo_rgb888_24bpp_pixel_getter() {
+    let raw = draw_raw::<Bgr888>(include_bytes!("logo-rgb888.raw"));
+    let bmp = draw_bmp_pixel_getter::<Bgr888>(include_bytes!("logo-rgb888-24bpp.bmp"));
+
+    bmp.assert_eq(&raw);
+}
+
+#[test]
 fn logo_rgb888_32bpp() {
     let raw = draw_raw::<Bgr888>(include_bytes!("logo-rgb888.raw"));
     let bmp = draw_bmp::<Bgr888>(include_bytes!("logo-rgb888-32bpp.bmp"));
+
+    bmp.assert_eq(&raw);
+}
+
+#[test]
+fn logo_rgb888_32bpp_pixel_getter() {
+    let raw = draw_raw::<Bgr888>(include_bytes!("logo-rgb888.raw"));
+    let bmp = draw_bmp_pixel_getter::<Bgr888>(include_bytes!("logo-rgb888-32bpp.bmp"));
 
     bmp.assert_eq(&raw);
 }


### PR DESCRIPTION
This PR adds pixel getters to `Bmp` and `RawBmp`. It doesn't yet implement the new `ImagePixelGetter` trait (https://github.com/embedded-graphics/embedded-graphics/pull/612) to stay compatible with e-g `0.7`.