### PR TITLE
Update to e-g 0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 
 ### Changed
 
-- **(breaking)** [#XX](https://github.com/embedded-graphics/tinybmp/pull/XX) Updated `embedded-graphics` dependency to `0.8`.
+- **(breaking)** [#39](https://github.com/embedded-graphics/tinybmp/pull/39) Updated `embedded-graphics` dependency to `0.8`.
+- **(breaking)** [#39](https://github.com/embedded-graphics/tinybmp/pull/39) Replaced `Bmp::pixel` method with `embedded_graphics::image::GetPixel` impl.
 
 ## [0.4.0] - 2022-09-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- **(breaking)** [#XX](https://github.com/embedded-graphics/tinybmp/pull/XX) Updated `embedded-graphics` dependency to `0.8`.
+
 ## [0.4.0] - 2022-09-30
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,9 @@ name = "draw"
 harness = false
 
 [dependencies]
-embedded-graphics = "0.7.1"
+embedded-graphics = "0.8.0"
 
 [dev-dependencies]
 clap = { version = "3.1.6", features = ["derive"] }
 criterion = "0.3.5"
-embedded-graphics-simulator = "0.3.0"
+embedded-graphics-simulator = "0.5.0"

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ for Pixel(position, color) in bmp.pixels() {
 converted to one of the [color types] in [`embedded_graphics`].
 
 ```rust
-use embedded_graphics::{pixelcolor::Rgb888, prelude::*};
+use embedded_graphics::{pixelcolor::Rgb888, image::GetPixel, prelude::*};
 use tinybmp::Bmp;
 
 // Include the BMP file data.

--- a/tests/logo.rs
+++ b/tests/logo.rs
@@ -1,5 +1,5 @@
 use embedded_graphics::{
-    image::{Image, ImageRaw},
+    image::{GetPixel, Image, ImageRaw},
     iterator::raw::RawDataSlice,
     pixelcolor::{raw::LittleEndian, Bgr888, Rgb555, Rgb565, Rgb888},
     prelude::*,


### PR DESCRIPTION
This PR updates the `embedded-graphics` dependency to 0.8 and replaces `Bmp::pixel` with an equivalent `GetPixel` impl.
