### PR TITLE
Constify `Bmp::from_slice`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ## [Unreleased] - ReleaseDate
 
+- [#46](https://github.com/embedded-graphics/tinybmp/pull/46) `Bmp::from_slice` is now `const`, so BMPs can be put in `const`s and `static`s.
+
+
 ## [0.6.0] - 2024-06-11
 
 ### Added

--- a/src/header/dib_header.rs
+++ b/src/header/dib_header.rs
@@ -5,7 +5,7 @@ use embedded_graphics::prelude::*;
 use crate::{
     header::CompressionMethod,
     parser::{le_i32, le_u16, le_u32, take_slice},
-    propagate, Bpp, ChannelMasks, ParseError, RowOrder,
+    try_const, Bpp, ChannelMasks, ParseError, RowOrder,
 };
 
 const DIB_INFO_HEADER_SIZE: u32 = 40;
@@ -28,14 +28,14 @@ pub struct DibHeader {
 
 impl DibHeader {
     pub const fn parse(input: &[u8]) -> Result<(&[u8], Self), ParseError> {
-        let (input, dib_header_length) = propagate!(le_u32(input));
+        let (input, dib_header_length) = try_const!(le_u32(input));
 
         // The header size in the BMP includes its own u32, so we strip it out by subtracting 4
         // bytes to get the right final offset to the end of the header.
         let Some(data_length) = dib_header_length.checked_sub(4) else {
             return Err(ParseError::UnsupportedHeaderLength(dib_header_length));
         };
-        let (input, dib_header_data) = propagate!(take_slice(input, data_length as usize));
+        let (input, dib_header_data) = try_const!(take_slice(input, data_length as usize));
 
         // Add 4 back on so the constants remain the correct size relative to the BMP
         // documentation/specs.
@@ -48,30 +48,30 @@ impl DibHeader {
         };
 
         // Fields common to all DIB variants
-        let (dib_header_data, image_width) = propagate!(le_i32(dib_header_data));
-        let (dib_header_data, image_height) = propagate!(le_i32(dib_header_data));
-        let (dib_header_data, _color_planes) = propagate!(le_u16(dib_header_data));
-        let (dib_header_data, bpp) = propagate!(Bpp::parse(dib_header_data));
+        let (dib_header_data, image_width) = try_const!(le_i32(dib_header_data));
+        let (dib_header_data, image_height) = try_const!(le_i32(dib_header_data));
+        let (dib_header_data, _color_planes) = try_const!(le_u16(dib_header_data));
+        let (dib_header_data, bpp) = try_const!(Bpp::parse(dib_header_data));
 
         // Extra fields defined by DIB variants
         // Variants are described in
         // <https://www.liquisearch.com/bmp_file_format/file_structure/dib_header_bitmap_information_header>
         // and <https://docs.microsoft.com/en-us/windows/win32/gdi/bitmap-header-types>
         let (dib_header_data, compression_method) =
-            propagate!(CompressionMethod::parse(dib_header_data));
-        let (dib_header_data, image_data_len) = propagate!(le_u32(dib_header_data));
-        let (dib_header_data, _pels_per_meter_x) = propagate!(le_u32(dib_header_data));
-        let (dib_header_data, _pels_per_meter_y) = propagate!(le_u32(dib_header_data));
-        let (dib_header_data, colors_used) = propagate!(le_u32(dib_header_data));
-        let (dib_header_data, _colors_important) = propagate!(le_u32(dib_header_data));
+            try_const!(CompressionMethod::parse(dib_header_data));
+        let (dib_header_data, image_data_len) = try_const!(le_u32(dib_header_data));
+        let (dib_header_data, _pels_per_meter_x) = try_const!(le_u32(dib_header_data));
+        let (dib_header_data, _pels_per_meter_y) = try_const!(le_u32(dib_header_data));
+        let (dib_header_data, colors_used) = try_const!(le_u32(dib_header_data));
+        let (dib_header_data, _colors_important) = try_const!(le_u32(dib_header_data));
 
         let (_dib_header_data, channel_masks) = if header_type.is_at_least(HeaderType::V3)
             && matches!(compression_method, CompressionMethod::Bitfields)
         {
-            let (dib_header_data, mask_red) = propagate!(le_u32(dib_header_data));
-            let (dib_header_data, mask_green) = propagate!(le_u32(dib_header_data));
-            let (dib_header_data, mask_blue) = propagate!(le_u32(dib_header_data));
-            let (dib_header_data, mask_alpha) = propagate!(le_u32(dib_header_data));
+            let (dib_header_data, mask_red) = try_const!(le_u32(dib_header_data));
+            let (dib_header_data, mask_green) = try_const!(le_u32(dib_header_data));
+            let (dib_header_data, mask_blue) = try_const!(le_u32(dib_header_data));
+            let (dib_header_data, mask_alpha) = try_const!(le_u32(dib_header_data));
 
             (
                 dib_header_data,
@@ -129,18 +129,6 @@ pub enum HeaderType {
 
 impl HeaderType {
     const fn is_at_least(self, header_type: HeaderType) -> bool {
-        matches!(
-            (self, header_type),
-            (Self::V5, Self::V5)
-                | (Self::V5, Self::V4)
-                | (Self::V5, Self::V3)
-                | (Self::V5, Self::Info)
-                | (Self::V4, Self::V4)
-                | (Self::V4, Self::V3)
-                | (Self::V4, Self::Info)
-                | (Self::V3, Self::V3)
-                | (Self::V3, Self::Info)
-                | (Self::Info, Self::Info)
-        )
+        self as u8 >= header_type as u8
     }
 }

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -7,8 +7,8 @@ use embedded_graphics::prelude::*;
 
 use crate::{
     color_table::ColorTable,
-    parser::{le_u16, le_u32, take, take_slice},
-    ParseError,
+    parser::{le_u16, le_u32, take2, take_slice},
+    propagate, ParseError,
 };
 
 mod dib_header;
@@ -46,8 +46,9 @@ impl Bpp {
         })
     }
 
-    fn parse(input: &[u8]) -> Result<(&[u8], Self), ParseError> {
-        le_u16(input).and_then(|(input, value)| Ok((input, Self::new(value)?)))
+    const fn parse(input: &[u8]) -> Result<(&[u8], Self), ParseError> {
+        let (input, value) = propagate!(le_u16(input));
+        Ok((input, propagate!(Self::new(value))))
     }
 
     /// Returns the number of bits.
@@ -110,27 +111,31 @@ pub struct Header {
 }
 
 impl Header {
-    pub(crate) fn parse(
+    pub(crate) const fn parse(
         input: &[u8],
     ) -> Result<(&[u8], (Header, Option<ColorTable<'_>>)), ParseError> {
         // File header
-        let (input, magic) = take::<2>(input)?;
-        if &magic != b"BM" {
+        let (input, magic) = propagate!(take2(input));
+
+        if let b"BM" = &magic {
+        } else {
             return Err(ParseError::InvalidFileSignature(magic));
         }
 
-        let (input, file_size) = le_u32(input)?;
-        let (input, _reserved_1) = le_u16(input)?;
-        let (input, _reserved_2) = le_u16(input)?;
-        let (input, image_data_start) = le_u32(input)?;
+        let (input, file_size) = propagate!(le_u32(input));
+        let (input, _reserved_1) = propagate!(le_u16(input));
+        let (input, _reserved_2) = propagate!(le_u16(input));
+        let (input, image_data_start) = propagate!(le_u32(input));
 
         // DIB header
-        let (input, dib_header) = DibHeader::parse(input)?;
+        let (input, dib_header) = propagate!(DibHeader::parse(input));
 
         let (input, color_table) = if dib_header.color_table_num_entries > 0 {
             // Each color table entry is 4 bytes long
-            let (input, table) =
-                take_slice(input, dib_header.color_table_num_entries as usize * 4)?;
+            let (input, table) = propagate!(take_slice(
+                input,
+                dib_header.color_table_num_entries as usize * 4
+            ));
             (input, Some(ColorTable::new(table)))
         } else {
             (input, None)
@@ -231,7 +236,8 @@ impl CompressionMethod {
         })
     }
 
-    fn parse(input: &[u8]) -> Result<(&[u8], Self), ParseError> {
-        le_u32(input).and_then(|(input, value)| Ok((input, Self::new(value)?)))
+    const fn parse(input: &[u8]) -> Result<(&[u8], Self), ParseError> {
+        let (input, value) = propagate!(le_u32(input));
+        Ok((input, propagate!(Self::new(value))))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,7 +192,9 @@ mod parser;
 mod raw_bmp;
 mod raw_iter;
 
-macro_rules! propagate {
+/// Alternative to the `?` operator that is usable in const contexts.
+// MSRV: Replace macro with `?` operator when it get gets supported in const contexts.
+macro_rules! try_const {
     ($e:expr) => {
         match $e {
             Ok(ok) => ok,
@@ -200,7 +202,7 @@ macro_rules! propagate {
         }
     };
 }
-pub(crate) use propagate;
+pub(crate) use try_const;
 
 use raw_bmp::ColorType;
 use raw_iter::{RawColors, Rle4Pixels, Rle8Pixels};
@@ -230,7 +232,7 @@ where
     /// The created object keeps a shared reference to the input and does not dynamically allocate
     /// memory.
     pub const fn from_slice(bytes: &'a [u8]) -> Result<Self, ParseError> {
-        let raw_bmp = propagate!(RawBmp::from_slice(bytes));
+        let raw_bmp = try_const!(RawBmp::from_slice(bytes));
 
         Ok(Self {
             raw_bmp,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,6 +192,16 @@ mod parser;
 mod raw_bmp;
 mod raw_iter;
 
+macro_rules! propagate {
+    ($e:expr) => {
+        match $e {
+            Ok(ok) => ok,
+            Err(e) => return Err(e),
+        }
+    };
+}
+pub(crate) use propagate;
+
 use raw_bmp::ColorType;
 use raw_iter::{RawColors, Rle4Pixels, Rle8Pixels};
 
@@ -219,8 +229,8 @@ where
     ///
     /// The created object keeps a shared reference to the input and does not dynamically allocate
     /// memory.
-    pub fn from_slice(bytes: &'a [u8]) -> Result<Self, ParseError> {
-        let raw_bmp = RawBmp::from_slice(bytes)?;
+    pub const fn from_slice(bytes: &'a [u8]) -> Result<Self, ParseError> {
+        let raw_bmp = propagate!(RawBmp::from_slice(bytes));
 
         Ok(Self {
             raw_bmp,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,31 +1,41 @@
-use crate::ParseError;
+use crate::{propagate, ParseError};
 
-pub fn take<const N: usize>(input: &[u8]) -> Result<(&[u8], [u8; N]), ParseError> {
-    if let (Some(value), Some(rest)) = (input.get(0..N), input.get(N..)) {
-        Ok((rest, value.try_into().unwrap()))
+pub const fn take2(input: &[u8]) -> Result<(&[u8], [u8; 2]), ParseError> {
+    if let [a, b, rest @ ..] = input {
+        Ok((rest, [*a, *b]))
     } else {
         Err(ParseError::UnexpectedEndOfFile)
     }
 }
 
-pub fn take_slice(input: &[u8], length: usize) -> Result<(&[u8], &[u8]), ParseError> {
-    if let (Some(value), Some(rest)) = (input.get(0..length), input.get(length..)) {
+pub const fn take4(input: &[u8]) -> Result<(&[u8], [u8; 4]), ParseError> {
+    if let [a, b, c, d, rest @ ..] = input {
+        Ok((rest, [*a, *b, *c, *d]))
+    } else {
+        Err(ParseError::UnexpectedEndOfFile)
+    }
+}
+
+pub const fn take_slice(input: &[u8], length: usize) -> Result<(&[u8], &[u8]), ParseError> {
+    if length <= input.len() {
+        let (value, rest) = input.split_at(length);
         Ok((rest, value))
     } else {
         Err(ParseError::UnexpectedEndOfFile)
     }
 }
 
-pub fn le_u16(input: &[u8]) -> Result<(&[u8], u16), ParseError> {
-    let (input, value) = take::<2>(input)?;
+pub const fn le_u16(input: &[u8]) -> Result<(&[u8], u16), ParseError> {
+    let (input, value) = propagate!(take2(input));
     Ok((input, u16::from_le_bytes(value)))
 }
 
-pub fn le_u32(input: &[u8]) -> Result<(&[u8], u32), ParseError> {
-    let (input, value) = take::<4>(input)?;
+pub const fn le_u32(input: &[u8]) -> Result<(&[u8], u32), ParseError> {
+    let (input, value) = propagate!(take4(input));
     Ok((input, u32::from_le_bytes(value)))
 }
 
-pub fn le_i32(input: &[u8]) -> Result<(&[u8], i32), ParseError> {
-    le_u32(input).map(|(input, value)| (input, value as i32))
+pub const fn le_i32(input: &[u8]) -> Result<(&[u8], i32), ParseError> {
+    let (input, value) = propagate!(take4(input));
+    Ok((input, i32::from_le_bytes(value)))
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,5 +1,6 @@
-use crate::{propagate, ParseError};
+use crate::{try_const, ParseError};
 
+// MSRV: Use `split_at_checked` (1.80.0) and `split_first_chunk` (1.77.0) in this module.
 pub const fn take2(input: &[u8]) -> Result<(&[u8], [u8; 2]), ParseError> {
     if let [a, b, rest @ ..] = input {
         Ok((rest, [*a, *b]))
@@ -26,16 +27,16 @@ pub const fn take_slice(input: &[u8], length: usize) -> Result<(&[u8], &[u8]), P
 }
 
 pub const fn le_u16(input: &[u8]) -> Result<(&[u8], u16), ParseError> {
-    let (input, value) = propagate!(take2(input));
+    let (input, value) = try_const!(take2(input));
     Ok((input, u16::from_le_bytes(value)))
 }
 
 pub const fn le_u32(input: &[u8]) -> Result<(&[u8], u32), ParseError> {
-    let (input, value) = propagate!(take4(input));
+    let (input, value) = try_const!(take4(input));
     Ok((input, u32::from_le_bytes(value)))
 }
 
 pub const fn le_i32(input: &[u8]) -> Result<(&[u8], i32), ParseError> {
-    let (input, value) = propagate!(take4(input));
+    let (input, value) = try_const!(take4(input));
     Ok((input, i32::from_le_bytes(value)))
 }

--- a/src/raw_bmp.rs
+++ b/src/raw_bmp.rs
@@ -52,7 +52,7 @@ impl<'a> RawBmp<'a> {
             return Err(ParseError::UnexpectedEndOfFile);
         }
         let (_, image_data) = bytes.split_at(header.image_data_start);
-        if bytes.len() < compressed_data_length {
+        if image_data.len() < compressed_data_length {
             return Err(ParseError::UnexpectedEndOfFile);
         }
         let (image_data, _) = image_data.split_at(compressed_data_length);


### PR DESCRIPTION
Thank you for helping out with tinybmp development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR constifies the whole BMP parsing logic. Unfortunately it needs one `unsafe` call, as slice ranges (`&foo[x..y]`) are not available in `const`. The `?` operator is also not available, I get around this by defining a `propagate!` macro that does what `?` does but without calling `.into()` on the error.
