### PR TITLE
fix(rle): return all pixels instead of only first row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - [#55](https://github.com/embedded-graphics/tinybmp/pull/55) Added methods `CompressionMethod::is_compressed` and `Header::bytes_per_row`. The latter is essential information when walking through the bytes yourself.
 
+### Fixed
+
+- Fixed RLE4/RLE8 compressed BMP pixel iterator returning only the first row of pixels instead of all pixels.
+
 ## [0.7.0] - 2026-01-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Fixed
 
-- Fixed RLE4/RLE8 compressed BMP pixel iterator returning only the first row of pixels instead of all pixels.
+- [#57](https://github.com/embedded-graphics/tinybmp/pull/57) Fixed RLE4/RLE8 compressed BMP pixel iterator returning only the first row of pixels instead of all pixels.
 
 ## [0.7.0] - 2026-01-14
 

--- a/src/raw_iter.rs
+++ b/src/raw_iter.rs
@@ -213,7 +213,7 @@ impl<'a> Rle8Colors<'a> {
         Rle8Colors {
             data: raw_bmp.image_data(),
             rle_state: RleState::Starting,
-            start_of_row: false,
+            start_of_row: true,
         }
     }
 
@@ -252,6 +252,7 @@ impl<'a> Iterator for Rle8Colors<'a> {
                     } else {
                         self.data = self.data.get(1..)?;
                     }
+                    self.start_of_row = false;
                     return Some(RawU8::from(value));
                 }
                 RleState::Running {
@@ -268,6 +269,7 @@ impl<'a> Iterator for Rle8Colors<'a> {
                             is_odd,
                         };
                     }
+                    self.start_of_row = false;
                     return Some(RawU8::from(value));
                 }
                 RleState::Starting => {
@@ -284,9 +286,8 @@ impl<'a> Iterator for Rle8Colors<'a> {
                             // the pair, which can be one of the following values.
                             match param {
                                 0 => {
-                                    if !self.start_of_row {
-                                        return None;
-                                    }
+                                    // End of line - move to next row
+                                    self.start_of_row = true;
                                 }
                                 1 => {
                                     // End of bitmap
@@ -340,7 +341,7 @@ impl<'a> Rle4Colors<'a> {
         Rle4Colors {
             data: raw_bmp.image_data(),
             rle_state: RleState::Starting,
-            start_of_row: false,
+            start_of_row: true,
         }
     }
 
@@ -400,6 +401,7 @@ impl<'a> Iterator for Rle4Colors<'a> {
                         // remove the padding byte too
                         self.data = self.data.get(1..)?;
                     }
+                    self.start_of_row = false;
                     return Some(RawU4::from(nibble_value));
                 }
                 RleState::Running {
@@ -434,6 +436,7 @@ impl<'a> Iterator for Rle4Colors<'a> {
                         };
                     }
 
+                    self.start_of_row = false;
                     return Some(RawU4::from(nibble_value));
                 }
                 RleState::Starting => {
@@ -450,9 +453,8 @@ impl<'a> Iterator for Rle4Colors<'a> {
                             // the pair, which can be one of the following values.
                             match param {
                                 0 => {
-                                    if !self.start_of_row {
-                                        return None;
-                                    }
+                                    // End of line - move to next row
+                                    self.start_of_row = true;
                                 }
                                 1 => {
                                     // End of bitmap

--- a/tests/logo.rs
+++ b/tests/logo.rs
@@ -140,6 +140,12 @@ fn logo_indexed_1bpp_pixel_getter() {
 }
 
 #[test]
+fn logo_indexed_1bpp_pixel_iteration() {
+    let bmp: Bmp<'_, Bgr888> = Bmp::from_slice(include_bytes!("logo-indexed-1bpp.bmp")).unwrap();
+    assert_eq!(bmp.pixels().count(), WIDTH * HEIGHT);
+}
+
+#[test]
 fn logo_indexed_4bpp() {
     let raw = draw_raw::<Bgr888>(include_bytes!("logo-indexed-4bpp.raw"));
     let bmp = draw_bmp::<Bgr888>(include_bytes!("logo-indexed-4bpp.bmp"));
@@ -148,11 +154,23 @@ fn logo_indexed_4bpp() {
 }
 
 #[test]
+fn logo_indexed_4bpp_pixel_iteration() {
+    let bmp: Bmp<'_, Bgr888> = Bmp::from_slice(include_bytes!("logo-indexed-4bpp.bmp")).unwrap();
+    assert_eq!(bmp.pixels().count(), WIDTH * HEIGHT);
+}
+
+#[test]
 fn logo_indexed_4bpp_rle4() {
     let raw = draw_raw::<Bgr888>(include_bytes!("logo-indexed-4bpp.raw"));
     let bmp = draw_bmp::<Bgr888>(include_bytes!("logo-indexed-4bpp-rle4.bmp"));
 
     bmp.assert_eq(&raw);
+}
+
+#[test]
+fn logo_indexed_4bpp_rle4_pixel_iteration() {
+    let bmp: Bmp<'_, Bgr888> = Bmp::from_slice(include_bytes!("logo-indexed-4bpp-rle4.bmp")).unwrap();
+    assert_eq!(bmp.pixels().count(), WIDTH * HEIGHT);
 }
 
 #[test]
@@ -180,11 +198,23 @@ fn logo_indexed_8bpp_pixel_getter() {
 }
 
 #[test]
+fn logo_indexed_8bpp_pixel_iteration() {
+    let bmp: Bmp<'_, Bgr888> = Bmp::from_slice(include_bytes!("logo-indexed-8bpp.bmp")).unwrap();
+    assert_eq!(bmp.pixels().count(), WIDTH * HEIGHT);
+}
+
+#[test]
 fn logo_indexed_8bpp_rle8() {
     let raw = draw_raw::<Bgr888>(include_bytes!("logo-indexed-8bpp.raw"));
     let bmp = draw_bmp::<Bgr888>(include_bytes!("logo-indexed-8bpp-rle8.bmp"));
 
     bmp.assert_eq(&raw);
+}
+
+#[test]
+fn logo_indexed_8bpp_rle8_pixel_iteration() {
+    let bmp: Bmp<'_, Bgr888> = Bmp::from_slice(include_bytes!("logo-indexed-8bpp-rle8.bmp")).unwrap();
+    assert_eq!(bmp.pixels().count(), WIDTH * HEIGHT);
 }
 
 #[test]
@@ -204,6 +234,12 @@ fn logo_rgb555_pixel_getter() {
 }
 
 #[test]
+fn logo_rgb555_pixel_iteration() {
+    let bmp: Bmp<'_, Rgb555> = Bmp::from_slice(include_bytes!("logo-rgb555.bmp")).unwrap();
+    assert_eq!(bmp.pixels().count(), WIDTH * HEIGHT);
+}
+
+#[test]
 fn logo_rgb565() {
     let raw = draw_raw::<Rgb565>(include_bytes!("logo-rgb565.raw"));
     let bmp = draw_bmp::<Rgb565>(include_bytes!("logo-rgb565.bmp"));
@@ -217,6 +253,12 @@ fn logo_rgb565_pixel_getter() {
     let bmp = draw_bmp_pixel_getter::<Rgb565>(include_bytes!("logo-rgb565.bmp"));
 
     bmp.assert_eq(&raw);
+}
+
+#[test]
+fn logo_rgb565_pixel_iteration() {
+    let bmp: Bmp<'_, Rgb565> = Bmp::from_slice(include_bytes!("logo-rgb565.bmp")).unwrap();
+    assert_eq!(bmp.pixels().count(), WIDTH * HEIGHT);
 }
 
 #[test]
@@ -236,6 +278,12 @@ fn logo_rgb888_24bpp_pixel_getter() {
 }
 
 #[test]
+fn logo_rgb888_24bpp_pixel_iteration() {
+    let bmp: Bmp<'_, Bgr888> = Bmp::from_slice(include_bytes!("logo-rgb888-24bpp.bmp")).unwrap();
+    assert_eq!(bmp.pixels().count(), WIDTH * HEIGHT);
+}
+
+#[test]
 fn logo_rgb888_32bpp() {
     let raw = draw_raw::<Bgr888>(include_bytes!("logo-rgb888.raw"));
     let bmp = draw_bmp::<Bgr888>(include_bytes!("logo-rgb888-32bpp.bmp"));
@@ -249,4 +297,10 @@ fn logo_rgb888_32bpp_pixel_getter() {
     let bmp = draw_bmp_pixel_getter::<Bgr888>(include_bytes!("logo-rgb888-32bpp.bmp"));
 
     bmp.assert_eq(&raw);
+}
+
+#[test]
+fn logo_rgb888_32bpp_pixel_iteration() {
+    let bmp: Bmp<'_, Bgr888> = Bmp::from_slice(include_bytes!("logo-rgb888-32bpp.bmp")).unwrap();
+    assert_eq!(bmp.pixels().count(), WIDTH * HEIGHT);
 }

--- a/tests/logo.rs
+++ b/tests/logo.rs
@@ -169,7 +169,8 @@ fn logo_indexed_4bpp_rle4() {
 
 #[test]
 fn logo_indexed_4bpp_rle4_pixel_iteration() {
-    let bmp: Bmp<'_, Bgr888> = Bmp::from_slice(include_bytes!("logo-indexed-4bpp-rle4.bmp")).unwrap();
+    let bmp: Bmp<'_, Bgr888> =
+        Bmp::from_slice(include_bytes!("logo-indexed-4bpp-rle4.bmp")).unwrap();
     assert_eq!(bmp.pixels().count(), WIDTH * HEIGHT);
 }
 
@@ -213,7 +214,8 @@ fn logo_indexed_8bpp_rle8() {
 
 #[test]
 fn logo_indexed_8bpp_rle8_pixel_iteration() {
-    let bmp: Bmp<'_, Bgr888> = Bmp::from_slice(include_bytes!("logo-indexed-8bpp-rle8.bmp")).unwrap();
+    let bmp: Bmp<'_, Bgr888> =
+        Bmp::from_slice(include_bytes!("logo-indexed-8bpp-rle8.bmp")).unwrap();
     assert_eq!(bmp.pixels().count(), WIDTH * HEIGHT);
 }
 


### PR DESCRIPTION

- [x] Check that you've added passing tests and documentation
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## Problem

When iterating over pixels of an RLE4 or RLE8 compressed BMP image using `Bmp::pixels()`, the iterator seems to only return pixels from the first row instead of all pixels in the image. (fixes: #56)

For example, with a 640×480 RLE8 image:
- Expected: `PixelCount: 307200` (640 × 480)
- Actual: `PixelCount: 640` (only one row)

## Root Cause

It looks like this was introduced in commit d61a220, which refactored the RLE decoder to use a `start_of_row` flag instead of tracking absolute pixel coordinates. There appear to be two issues:

1. **`start_of_row` initialized to `false`**: Both `Rle8Colors::new()` and `Rle4Colors::new()` initialize `start_of_row` to `false`, but the flag is only set to `true` when `start_row()` is explicitly called. When using `Bmp::pixels()` (which doesn't call `start_row()`), the iterator starts with `start_of_row = false`.

2. **End-of-line escape handler returns `None`**: When the decoder encounters an end-of-line marker (`00 00`), the code checks `if !self.start_of_row { return None; }`. Since `start_of_row` is `false` at the start, the iterator terminates early after processing the first row's end-of-line marker.

## Proposed Fix

This PR attempts to fix the issue by:

- Initializing `start_of_row` to `true` in both `Rle8Colors::new()` and `Rle4Colors::new()`
- Setting `start_of_row = false` after returning each pixel (in both Absolute and Running modes)
- Changing the end-of-line escape handler from `return None` to `self.start_of_row = true` to properly transition to the next row

## Changes

- `src/raw_iter.rs`:
  - `Rle8Colors::new()`: `start_of_row: false` → `start_of_row: true`
  - `Rle4Colors::new()`: `start_of_row: false` → `start_of_row: true`
  - Added `self.start_of_row = false` before returning pixels in Absolute mode (Rle8Colors, Rle4Colors)
  - Added `self.start_of_row = false` before returning pixels in Running mode (Rle8Colors, Rle4Colors)
  - Changed end-of-line handler: `if !self.start_of_row { return None; }` → `self.start_of_row = true` (Rle8Colors, Rle4Colors)